### PR TITLE
Fixed Class Name

### DIFF
--- a/src/Caffeinated/Menus/Item.php
+++ b/src/Caffeinated/Menus/Item.php
@@ -1,7 +1,7 @@
 <?php
 namespace Caffeinated\Menus;
 
-use Request;
+use Illuminate\Support\Facades\Request;
 
 class Item
 {


### PR DESCRIPTION
We should use full class names instead of aliases because they can be disabled in app/config.
