### PR TITLE
If the icon type is not supported, render it in an <i> tag

### DIFF
--- a/src/Caffeinated/Menus/Item.php
+++ b/src/Caffeinated/Menus/Item.php
@@ -218,7 +218,7 @@ class Item
 				break;
 
 			default:
-				$html = '';
+				$html = '<i class="'.$icon.'"></i>';
 				break;
 		}
 


### PR DESCRIPTION
Allows support for all icon vendors
