### PR TITLE
Fix collection prepend

### DIFF
--- a/src/Caffeinated/Menus/Collection.php
+++ b/src/Caffeinated/Menus/Collection.php
@@ -66,9 +66,10 @@ class Collection extends BaseCollection
 	 * Prepends text or HTML to the collection of items.
 	 *
 	 * @param  string  $html
+	 * @param  mixed  $key
 	 * @return \Caffeinated\Menus\Collection
 	 */
-	public function prepend($html)
+	public function prepend($html, $key = null)
 	{
 		$this->each(function($item) use ($html) {
 			$item->title = $html.$item->title;


### PR DESCRIPTION
Makes it compatible with the version of Laravel released today (5.1.24).

[Here's the change](https://github.com/laravel/framework/pull/10811) that necessitates this.

Fixes #68
