### PR TITLE
Allow pattern prefix and HTTPS

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -333,8 +333,8 @@ class Item
 
 			list($path, $requestPath) = preg_replace('@^('.$base.')/@', '', [$path, $requestPath], 1);
 		}
-
-		if ($this->url() == Request::url()) {
+		
+		if ($this->url() == Request::url() || $this->url() == \URL::secure(Request::path())) {
 			$this->activate();
 		}
 	}

--- a/src/Item.php
+++ b/src/Item.php
@@ -359,7 +359,7 @@ class Item
 		if (! is_null($pattern)) {
 			$pattern = ltrim(preg_replace('/\/\*/', '(/.*)?', $pattern), '/');
 
-			if (preg_match("@^{$pattern}\z@", Request::path())) {
+			if (preg_match("@{$pattern}\z@", Request::path())) {
 				$this->activate();
 			}
 


### PR DESCRIPTION
Allowing HTTP requests returning as HTTPS to be set as active.
And allowing prefixes for patterns, like language prefixes.
