### PR TITLE
PROPOSAL: Add ability to change menu_ or keep prepend blank

### DIFF
--- a/config/menu.php
+++ b/config/menu.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'prepend' => 'menu_'
+];

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -66,7 +66,7 @@ class Menu
 
 			$this->collection->put($name, $menu);
 
-			$this->view->share('menu_'.$name, $menu);
+			$this->view->share(config('menu.prepend','menu_').$name, $menu);
 
 			return $menu;
 		}

--- a/src/MenusServiceProvider.php
+++ b/src/MenusServiceProvider.php
@@ -5,6 +5,10 @@ use Illuminate\Support\ServiceProvider;
 
 class MenusServiceProvider extends ServiceProvider {
 
+    public function boot()
+    {
+        $this->publishConfig();
+    }
 	/**
 	 * Indicates if loading of the provider is deferred.
 	 *
@@ -47,4 +51,11 @@ class MenusServiceProvider extends ServiceProvider {
 			return new Menu($app['config'], $app['view'], $app['html'], $app['url']);
 		});
 	}
+
+    protected function publishConfig()
+    {
+        $this->publishes([
+            __DIR__ . '/../config/menu.php' => config_path('menu.php'),
+        ], 'caffeinated-menu');
+    }
 }


### PR DESCRIPTION
## This will allow changing of prepended value.

```blade
@include('layouts.site-menu', ['items' => $siteMenu->roots()])
```

or

```blade
@include('layouts.site-menu', ['items' => $menuSiteMenu->roots()])
```

Instead of

```blade
@include('layouts.site-menu', ['items' => $menu_siteMenu->roots()])
```

Now publishes `config/menu.php` config file

```bash
php artisan vendor:publish --tag=caffeinated-menu
```

## Default Config

```php
<?php

return [
    'prepend' => 'menu_'
];
```