### PR TITLE
Add support for Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*",
-        "illuminate/config": "5.5.*|5.6.*|5.7.*",
-        "illuminate/routing": "5.5.*|5.6.*|5.7.*",
-        "illuminate/view": "5.5.*|5.6.*|5.7.*"
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/config": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/view": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR updates the composer dependencies so Laravel 5.8 is supported.