### PR TITLE
PHP 7.4 Update

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -320,7 +320,7 @@ class Item
         $path        = ltrim(parse_url($this->url(), PHP_URL_PATH), '/');
         $requestPath = Request::path();
 
-        if ($this->builder->config['rest_base']) {
+        if (isset($this->builder->config) && $this->builder->config['rest_base']) {
             $base = (is_array($this->builder->config['rest_base'])) ? implode('|', $this->builder->config['rest_base']) : $this->builder->conf['rest_base'];
 
             list($path, $requestPath) = preg_replace('@^('.$base.')/@', '', [$path, $requestPath], 1);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -63,7 +63,7 @@ class Menu
 			return array_merge($options['default'], $options[$name]);
 		}
 
-		return $options['default'];
+		return $options['default'] ?? null;
 	}
 
 	/**


### PR DESCRIPTION
Removes incorrect array references that broke in PHP 7.4 as a result of calling an array offset on a null value/property. For reference, in the `loadConfig()` method in `Menus.php`: 

```
return $options['default'];
```

On previous versions of PHP, this would evaluate as `null` when `$options` was equal to `null`. However, in PHP 7.4, referencing a null value as an array is no longer permitted, so errors were being thrown.