### PR TITLE
Laravel 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^6.0"
+        "illuminate/support": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds support for Laravel 7.0.

As far as I know, there is no breaking change between 6 and 7, so it should be fine